### PR TITLE
Updated ignore file to exclude user and build files that should not be checked into source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,25 @@
 Thumbs.db
 ehthumbs.db
 
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+*project.lock.json
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+
 # Folder config file
 Desktop.ini
 

--- a/BLE-Pairing/code/BT-BeaconApp/DisplayHelper.cs
+++ b/BLE-Pairing/code/BT-BeaconApp/DisplayHelper.cs
@@ -72,9 +72,9 @@ public class DeviceInformationDisplay : INotifyPropertyChanged
         get
         {
             int val = int.MinValue;
-            int.TryParse(deviceInfo.Properties["System.Devices.Aep.SignalStrength"]
-                .ToString(), out val);
-
+            var property = deviceInfo.Properties["System.Devices.Aep.SignalStrength"];
+            if (property != null)
+                int.TryParse(property.ToString(), out val);
             return val;
         }
     }


### PR DESCRIPTION
This should stop a number of the files that show up as needing to be checked into source control after the solution is compiled.  Also there were some BLE devices that returned a null for the strength property causing an exception.
